### PR TITLE
Support for Kafka in observer broadcast

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
     runs-on: ubuntu-latest
     container: python:${{ matrix.python-version }}
     steps:

--- a/services.txt
+++ b/services.txt
@@ -1,0 +1,1 @@
+kafka-python

--- a/src/colony/libs/__init__.py
+++ b/src/colony/libs/__init__.py
@@ -103,7 +103,7 @@ from .number_util import get_number_length, get_digit, to_fixed
 from .object_util import object_attribute_names, object_attribute_values, object_flatten,\
     object_print_list, object_print
 from .observer_util import unique, notify, message, action, progress, register_g,\
-    unregister_g, notify_g
+    unregister_g, notify_g, notify_b, notify_kafka
 from .os_util import kill_process
 from .path_util import SEPARATOR, normalize_path, align_path, copy_directory, copy_link, copy_file,\
     remove_directory, link, link_copy, ensure_file_path, is_parent_path, relative_path

--- a/src/colony/libs/observer_util.py
+++ b/src/colony/libs/observer_util.py
@@ -60,6 +60,10 @@ GLOBAL_HANDLERS_MAP = {}
 """ The global handlers map to be used by default if
 no specific handlers map is defined """
 
+KAFKA_PRODUCERS = {}
+""" Global map that associates hosts with producers,
+to be used to power singleton based retrieval """
+
 def unique():
     """
     Generates a new pseudo unique identifier generated in the
@@ -233,7 +237,6 @@ def notify_g(operation_name, *arguments, **named_arguments):
     return notify(operation_name, None, *arguments, **named_arguments)
 
 def notify_b(operation_name, *arguments, **named_arguments):
-    notify_g(operation_name, *arguments, **named_arguments)
     notify_kafka(operation_name, *arguments, **named_arguments)
 
 def notify_kafka(operation_name, *arguments, **named_arguments):
@@ -258,9 +261,12 @@ def _get_kafka_producer():
     except Exception: return None
 
     kafka_host = config.conf("KAFKA_HOST", "localhost:19092")
+    if kafka_host in KAFKA_PRODUCERS:
+        return KAFKA_PRODUCERS[kafka_host]
 
     producer = kafka.KafkaProducer(
         bootstrap_servers = kafka_host
     )
+    KAFKA_PRODUCERS[kafka_host] = producer
 
     return producer

--- a/src/colony/libs/observer_util.py
+++ b/src/colony/libs/observer_util.py
@@ -37,6 +37,8 @@ __copyright__ = "Copyright (c) 2008-2022 Hive Solutions Lda."
 __license__ = "Apache License, Version 2.0"
 """ The license for the module """
 
+import json
+
 from colony.base import config, legacy
 
 COUNTER = 0
@@ -242,7 +244,6 @@ def notify_b(operation_name, *arguments, **named_arguments):
 def notify_kafka(operation_name, *arguments, **named_arguments):
     kafka_topic = config.conf("KAFKA_TOPIC", "colony")
 
-    import json
     message = dict(
         name = operation_name,
         args = arguments,
@@ -260,7 +261,9 @@ def _get_kafka_producer():
     try: import kafka
     except Exception: return None
 
-    kafka_host = config.conf("KAFKA_HOST", "localhost:19092")
+    kafka_host = config.conf("KAFKA_HOST", None)
+    if not kafka_host: return None
+
     if kafka_host in KAFKA_PRODUCERS:
         return KAFKA_PRODUCERS[kafka_host]
 

--- a/src/colony/libs/observer_util.py
+++ b/src/colony/libs/observer_util.py
@@ -242,7 +242,12 @@ def notify_b(operation_name, *arguments, **named_arguments):
     notify_kafka(operation_name, *arguments, **named_arguments)
 
 def notify_kafka(operation_name, *arguments, **named_arguments):
+    kafka_host = config.conf("KAFKA_HOST", None)
     kafka_topic = config.conf("KAFKA_TOPIC", "colony")
+
+    # in case no Kafka host is defined we act as if no need
+    # for the Kafka notification has been requested
+    if not kafka_host: return None
 
     message = dict(
         name = operation_name,
@@ -258,11 +263,11 @@ def notify_kafka(operation_name, *arguments, **named_arguments):
     producer.send(kafka_topic, data_b)
 
 def _get_kafka_producer():
-    kafka_host = config.conf("KAFKA_HOST", None)
-    if not kafka_host: return None
-
     try: import kafka
     except Exception: return None
+
+    kafka_host = config.conf("KAFKA_HOST", None)
+    if not kafka_host: return None
 
     if kafka_host in KAFKA_PRODUCERS:
         return KAFKA_PRODUCERS[kafka_host]

--- a/src/colony/libs/observer_util.py
+++ b/src/colony/libs/observer_util.py
@@ -258,11 +258,11 @@ def notify_kafka(operation_name, *arguments, **named_arguments):
     producer.send(kafka_topic, data_b)
 
 def _get_kafka_producer():
-    try: import kafka
-    except Exception: return None
-
     kafka_host = config.conf("KAFKA_HOST", None)
     if not kafka_host: return None
+
+    try: import kafka
+    except Exception: return None
 
     if kafka_host in KAFKA_PRODUCERS:
         return KAFKA_PRODUCERS[kafka_host]

--- a/src/colony/libs/observer_util.py
+++ b/src/colony/libs/observer_util.py
@@ -248,6 +248,9 @@ def notify_kafka(operation_name, *arguments, **named_arguments):
     data = json.dumps(message)
     data_b = legacy.bytes(data, encoding = "utf-8", force = True)
 
+    producer = _get_kafka_producer()
+    if not producer: return
+
     producer.send(kafka_topic, data_b)
 
 def _get_kafka_producer():
@@ -255,7 +258,6 @@ def _get_kafka_producer():
     except Exception: return None
 
     kafka_host = config.conf("KAFKA_HOST", "localhost:19092")
-    
 
     producer = kafka.KafkaProducer(
         bootstrap_servers = kafka_host


### PR DESCRIPTION
## Description

Added support for broadcast notification and created a first adapter for Kafka.

The main methods that were created are:

* `notify_b` - As an entrypoint for broadcast notification
* `notify_kafka` - For Kafka specific notification